### PR TITLE
make it possible to enable or disable adjusting to statusbar

### DIFF
--- a/app/src/main/java/com/andrognito/flashbardemo/KotlinSampleActivity.kt
+++ b/app/src/main/java/com/andrognito/flashbardemo/KotlinSampleActivity.kt
@@ -21,7 +21,7 @@ class KotlinSampleActivity : AppCompatActivity() {
 
         show.setOnClickListener {
             if (flashbar == null) {
-                flashbar = basic()
+                flashbar = iconAdvanced()
             }
             flashbar?.show()
         }
@@ -219,6 +219,17 @@ class KotlinSampleActivity : AppCompatActivity() {
                 .showIcon()
                 .icon(R.drawable.ic_drop)
                 .iconColorFilterRes(R.color.colorAccent)
+                .build()
+    }
+
+    private fun statusbarNotAdjusted(): Flashbar {
+        return Flashbar.Builder(this)
+                .gravity(Flashbar.Gravity.TOP)
+                .title("Hello World!")
+                .message("You can show a default icon on the left side of the with view.")
+                .backgroundColorRes(R.color.colorPrimaryDark)
+                .showIcon()
+                .adjustToStatusBar(false)
                 .build()
     }
 

--- a/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
@@ -56,8 +56,8 @@ class Flashbar private constructor(private var builder: Builder) {
         flashbarContainerView.addParent(this)
 
         flashbarView = FlashbarView(builder.activity)
-        flashbarView.init(builder.gravity, builder.castShadow, builder.shadowStrength!!)
-        flashbarView.adjustWitPositionAndOrientation(builder.activity, builder.gravity)
+        flashbarView.init(builder.gravity, builder.castShadow, builder.shadowStrength)
+        flashbarView.adjustWitPositionAndOrientation(builder.activity, builder.gravity, builder.adjustToStatusbar)
         flashbarView.addParent(flashbarContainerView)
 
         flashbarContainerView.attach(flashbarView)
@@ -222,6 +222,8 @@ class Flashbar private constructor(private var builder: Builder) {
 
         internal var enterAnimBuilder: FlashAnimBarBuilder? = null
         internal var exitAnimBuilder: FlashAnimBarBuilder? = null
+
+        internal var adjustToStatusbar: Boolean = true
 
         /**
          * Specifies the gravity from where the flashbar will be shown (top/bottom)
@@ -726,6 +728,10 @@ class Flashbar private constructor(private var builder: Builder) {
          */
         fun progressTintRes(@ColorRes colorId: Int) = apply {
             this.progressTint = ContextCompat.getColor(activity, colorId)
+        }
+
+        fun adjustToStatusBar(adjust: Boolean) = apply {
+            this.adjustToStatusbar = adjust
         }
 
         /**

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
@@ -89,9 +89,15 @@ internal class FlashbarView(context: Context) : LinearLayout(context) {
     }
 
     internal fun adjustWitPositionAndOrientation(activity: Activity,
-                                                 gravity: Gravity) {
+                                                 gravity: Gravity,
+                                                 adjustToStatusBar: Boolean) {
         val flashbarViewLp = RelativeLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
-        val statusBarHeight = activity.getStatusBarHeightInPx()
+
+        val statusBarHeight = if (adjustToStatusBar) {
+            activity.getStatusBarHeightInPx()
+        } else {
+            0
+        }
 
         val flashbarViewContentLp = fbContent.layoutParams as LinearLayout.LayoutParams
 


### PR DESCRIPTION
When there is an activity that has a statusbar, there is a padding with the height of statusbar is added on top of the flashbar if it is used with `Gravity.TOP`. With the auto-adjusting of flashbar height, the flashbar has a different height when it is shown in a fullscreen activity (no statusbar) and a normal activity. This PR adds the builder an option to disable auto-adjusting of the flashbar height based on statusbar.