### PR TITLE
Bugfix: Show Flashbar on top of a dialog

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,6 @@ android {
 dependencies {
     implementation project(':flashbar')
 
-    implementation "com.android.support:appcompat-v7:$versions.supportVersion"
+    implementation "androidx.appcompat:appcompat:$versions.appCompatVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
 }

--- a/app/src/main/java/com/andrognito/flashbardemo/JavaSampleActivity.java
+++ b/app/src/main/java/com/andrognito/flashbardemo/JavaSampleActivity.java
@@ -2,13 +2,14 @@ package com.andrognito.flashbardemo;
 
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v4.content.ContextCompat;
-import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.ImageView.ScaleType;
+
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
 
 import com.andrognito.flashbar.Flashbar;
 import com.andrognito.flashbar.anim.FlashAnim;

--- a/app/src/main/java/com/andrognito/flashbardemo/KotlinSampleActivity.kt
+++ b/app/src/main/java/com/andrognito/flashbardemo/KotlinSampleActivity.kt
@@ -2,9 +2,9 @@ package com.andrognito.flashbardemo
 
 import android.graphics.Typeface
 import android.os.Bundle
-import android.support.v4.content.ContextCompat
-import android.support.v7.app.AppCompatActivity
 import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import com.andrognito.flashbar.Flashbar
 import com.andrognito.flashbar.anim.FlashAnim
 import kotlinx.android.synthetic.main.activity_main.*

--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,17 @@
 buildscript {
     ext.versions = [
-            sdkMin        : 14,
-            sdkTarget     : 27,
-            kotlin        : '1.2.50',
-            supportVersion: '27.1.1'
+            sdkMin        : 21,
+            sdkTarget     : 30,
+            kotlin        : '1.4.20',
+            appCompatVersion: '1.2.0'
     ]
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.4.20'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'

--- a/flashbar/build.gradle
+++ b/flashbar/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: "maven-publish"
 
 ext {
     bintrayRepo = 'maven'
@@ -15,7 +16,7 @@ ext {
     siteUrl = 'https://github.com/aritraroy/Flashbar'
     gitUrl = 'https://github.com/aritraroy/Flashbar.git'
 
-    libraryVersion = '1.0.2'
+    libraryVersion = '1.0.4-mimo'
 
     developerId = 'aritraroy'
     developerName = 'Aritra Roy'
@@ -46,3 +47,25 @@ dependencies {
 
 apply from: 'https://raw.githubusercontent.com/aritraroy/LibUtils/master/install.gradle'
 apply from: 'https://raw.githubusercontent.com/aritraroy/LibUtils/master/upload.gradle'
+
+publishing {
+    publications {
+        aar(MavenPublication) {
+            groupId "com.andrognito.flashbar"
+            artifactId 'flashbar'
+            version '1.0.4-mimo'
+            artifact("$buildDir/outputs/aar/flashbar-release.aar")
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/getmimo/androidapp")
+            credentials {
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
+}

--- a/flashbar/build.gradle
+++ b/flashbar/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    implementation "com.android.support:appcompat-v7:$versions.supportVersion"
+    implementation "androidx.appcompat:appcompat:$versions.appCompatVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin"
 }
 

--- a/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
@@ -5,11 +5,11 @@ import android.graphics.Bitmap
 import android.graphics.PorterDuff
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
-import android.support.annotation.*
-import android.support.v4.content.ContextCompat
 import android.text.Spanned
 import android.widget.ImageView.ScaleType
 import android.widget.ImageView.ScaleType.CENTER_CROP
+import androidx.annotation.*
+import androidx.core.content.ContextCompat
 import com.andrognito.flashbar.Flashbar.Gravity.BOTTOM
 import com.andrognito.flashbar.Flashbar.Gravity.TOP
 import com.andrognito.flashbar.anim.FlashAnim

--- a/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/Flashbar.kt
@@ -6,6 +6,7 @@ import android.graphics.PorterDuff
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.text.Spanned
+import android.view.Window
 import android.widget.ImageView.ScaleType
 import android.widget.ImageView.ScaleType.CENTER_CROP
 import androidx.annotation.*
@@ -28,7 +29,7 @@ class Flashbar private constructor(private var builder: Builder) {
      * Shows a flashbar
      */
     fun show() {
-        flashbarContainerView.show(builder.activity)
+        flashbarContainerView.show(builder.activity, builder.window)
     }
 
     /**
@@ -147,7 +148,11 @@ class Flashbar private constructor(private var builder: Builder) {
         }
     }
 
-    class Builder(internal var activity: Activity) {
+    class Builder @JvmOverloads constructor(
+            internal var activity: Activity,
+            internal val window: Window? = null
+    ) {
+
         internal var layoutId: Int = R.layout.flash_bar_view
 
         internal var gravity: Gravity = BOTTOM

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarContainerView.kt
@@ -9,6 +9,8 @@ import android.view.MotionEvent.ACTION_DOWN
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.view.Window
 import android.widget.RelativeLayout
 import com.andrognito.flashbar.Flashbar.Companion.DURATION_INDEFINITE
 import com.andrognito.flashbar.Flashbar.DismissEvent
@@ -132,15 +134,25 @@ internal class FlashbarContainerView(context: Context)
     }
 
 
-    internal fun show(activity: Activity) {
+    internal fun show(activity: Activity, window: Window?) {
         if (isBarShowing || isBarShown) return
 
-        val activityRootView = activity.getRootView() ?: return
-
         // Only add the withView to the parent once
-        if (this.parent == null) activityRootView.addView(this)
+        if (this.parent == null) {
+            // add to window if it was specified in the source builder
+            if (window != null) {
+                window.addContentView(this, ViewGroup.LayoutParams(
+                        MATCH_PARENT,
+                        WRAP_CONTENT
+                ))
+            } else {
+                val activityRootView = activity.getRootView() ?: return
 
-        activityRootView.afterMeasured {
+                activityRootView.addView(this)
+            }
+        }
+
+        afterMeasured {
             val enterAnim = enterAnimBuilder.withView(flashbarView).build()
             enterAnim.start(object : FlashAnim.InternalAnimListener {
                 override fun onStart() {

--- a/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/FlashbarView.kt
@@ -9,7 +9,6 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Build.VERSION.SDK_INT
 import android.os.Build.VERSION_CODES.M
-import android.support.annotation.ColorInt
 import android.text.Spanned
 import android.text.TextUtils
 import android.util.TypedValue
@@ -21,6 +20,7 @@ import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.RelativeLayout.ALIGN_PARENT_BOTTOM
 import android.widget.RelativeLayout.ALIGN_PARENT_TOP
+import androidx.annotation.ColorInt
 import com.andrognito.flashbar.Flashbar.Gravity
 import com.andrognito.flashbar.Flashbar.Gravity.BOTTOM
 import com.andrognito.flashbar.Flashbar.Gravity.TOP

--- a/flashbar/src/main/java/com/andrognito/flashbar/SwipeDismissTouchListener.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/SwipeDismissTouchListener.kt
@@ -4,11 +4,11 @@ import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.animation.ValueAnimator
 import android.os.Build
-import android.support.annotation.RequiresApi
 import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.View
 import android.view.ViewConfiguration
+import androidx.annotation.RequiresApi
 
 internal class SwipeDismissTouchListener(
         private val view: View,

--- a/flashbar/src/main/java/com/andrognito/flashbar/anim/BaseFlashAnimBuilder.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/anim/BaseFlashAnimBuilder.kt
@@ -1,10 +1,10 @@
 package com.andrognito.flashbar.anim
 
 import android.content.Context
-import android.support.annotation.CallSuper
-import android.support.annotation.InterpolatorRes
 import android.view.View
 import android.view.animation.*
+import androidx.annotation.CallSuper
+import androidx.annotation.InterpolatorRes
 import com.andrognito.flashbar.R
 
 abstract class BaseFlashAnimBuilder(private val context: Context) {

--- a/flashbar/src/main/java/com/andrognito/flashbar/anim/FlashAnimBarBuilder.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/anim/FlashAnimBarBuilder.kt
@@ -4,11 +4,11 @@ import android.animation.Animator
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.content.Context
-import android.support.annotation.InterpolatorRes
 import android.view.View
 import android.view.animation.AnticipateInterpolator
 import android.view.animation.Interpolator
 import android.view.animation.OvershootInterpolator
+import androidx.annotation.InterpolatorRes
 import com.andrognito.flashbar.Flashbar
 import com.andrognito.flashbar.Flashbar.Gravity.BOTTOM
 import com.andrognito.flashbar.Flashbar.Gravity.TOP
@@ -114,7 +114,7 @@ class FlashAnimBarBuilder(context: Context) : BaseFlashAnimBuilder(context) {
         // Slide from left/right animation is not specified, default top/bottom
         // animation is applied
         if (direction == null) {
-            translationAnim.propertyName = "translationY"
+            translationAnim.setPropertyName("translationY")
 
             when (type!!) {
                 ENTER -> when (gravity!!) {
@@ -127,7 +127,7 @@ class FlashAnimBarBuilder(context: Context) : BaseFlashAnimBuilder(context) {
                 }
             }
         } else {
-            translationAnim.propertyName = "translationX"
+            translationAnim.setPropertyName("translationX")
 
             when (type!!) {
                 ENTER -> when (direction!!) {
@@ -146,7 +146,7 @@ class FlashAnimBarBuilder(context: Context) : BaseFlashAnimBuilder(context) {
 
         if (alpha) {
             val alphaAnim = ObjectAnimator()
-            alphaAnim.propertyName = "alpha"
+            alphaAnim.setPropertyName("alpha")
             alphaAnim.target = view
 
             when (type!!) {

--- a/flashbar/src/main/java/com/andrognito/flashbar/anim/FlashAnimIconBuilder.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/anim/FlashAnimIconBuilder.kt
@@ -7,9 +7,9 @@ import android.animation.PropertyValuesHolder
 import android.animation.ValueAnimator.INFINITE
 import android.animation.ValueAnimator.REVERSE
 import android.content.Context
-import android.support.annotation.InterpolatorRes
 import android.view.View
 import android.view.animation.Interpolator
+import androidx.annotation.InterpolatorRes
 
 class FlashAnimIconBuilder(context: Context) : BaseFlashAnimBuilder(context) {
 

--- a/flashbar/src/main/java/com/andrognito/flashbar/view/FbProgress.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/view/FbProgress.kt
@@ -184,7 +184,7 @@ class FbProgress : View {
         }
     }
 
-    public override fun onSaveInstanceState(): Parcelable? {
+    public override fun onSaveInstanceState(): Parcelable {
         val superState = super.onSaveInstanceState()
 
         val ss = WheelSavedState(superState)
@@ -373,10 +373,9 @@ class FbProgress : View {
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
     private fun setAnimationEnabled() {
-        val currentApiVersion = android.os.Build.VERSION.SDK_INT
+        val currentApiVersion = Build.VERSION.SDK_INT
 
-        val animationValue: Float
-        animationValue = if (currentApiVersion >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+        val animationValue: Float = if (currentApiVersion >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             Settings.Global.getFloat(context.contentResolver,
                     Settings.Global.ANIMATOR_DURATION_SCALE, 1f)
         } else {
@@ -513,7 +512,7 @@ class FbProgress : View {
         var linearProgress: Boolean = false
         var fillRadius: Boolean = false
 
-        constructor(superState: Parcelable) : super(superState) {}
+        constructor(superState: Parcelable?) : super(superState)
 
         private constructor(`in`: Parcel) : super(`in`) {
             this.mProgress = `in`.readFloat()

--- a/flashbar/src/main/java/com/andrognito/flashbar/view/ShadowView.kt
+++ b/flashbar/src/main/java/com/andrognito/flashbar/view/ShadowView.kt
@@ -1,12 +1,10 @@
 package com.andrognito.flashbar.view
 
 import android.content.Context
-import android.os.Build.VERSION.SDK_INT
-import android.os.Build.VERSION_CODES.JELLY_BEAN
-import android.support.annotation.DrawableRes
-import android.support.v4.content.ContextCompat
 import android.util.AttributeSet
 import android.view.View
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
 import com.andrognito.flashbar.R
 import com.andrognito.flashbar.view.ShadowView.ShadowType.BOTTOM
 import com.andrognito.flashbar.view.ShadowView.ShadowType.TOP
@@ -26,11 +24,7 @@ internal class ShadowView @JvmOverloads constructor(
 
     private fun setShadow(@DrawableRes id: Int) {
         val shadow = ContextCompat.getDrawable(context, id)
-        if (SDK_INT >= JELLY_BEAN) {
-            this.background = shadow
-        } else {
-            this.setBackgroundDrawable(shadow)
-        }
+        this.background = shadow
     }
 
     enum class ShadowType {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,5 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Mar 27 23:30:11 IST 2018
+#Wed Nov 18 15:38:48 CET 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip


### PR DESCRIPTION
When flashbar is shown from a dialog, it will be rendered behind it (dimmed). This is because how window system works in Android and there is no real fix for that. I've solved it by using a window class and adding another `contentView` to it. It works for `BottomSheetDialog` however it will still fail for regular dialogs where window is smaller than actual screen.

I've also added all the gradle scripts required to publish it into github packages, so the `androidapp` can use it directly.